### PR TITLE
fixing sync error (parameter ordering issue)

### DIFF
--- a/airflow/hbc_deployment/scripts/sync_dags.sh
+++ b/airflow/hbc_deployment/scripts/sync_dags.sh
@@ -2,4 +2,4 @@
 AWS_PATH=$(which aws || echo "/usr/local/bin/aws")
 source /usr/local/airflow/scripts/commons.sh
 echo "Syncing dags" | addDate
-${AWS_PATH} s3 sync s3://airflow-dags/ /usr/local/airflow/dags  --delete --include "*.py" --exclude "*" | addDate
+${AWS_PATH} s3 sync s3://airflow-dags/ /usr/local/airflow/dags/  --delete --exclude "*" --include "*.py" | addDate


### PR DESCRIPTION
see from s3 docs:

>Any number of these parameters can be passed to a command. You can do this by providing an --exclude or --include argument multiple times, e.g. --include "*.txt" --include "*.png". When there are multiple filters, the rule is the filters that appear later in the command take precedence over filters that appear earlier in the command. For example, if the filter parameters passed to the command were

`--exclude "*" --include "*.txt"`

>All files will be excluded from the command except for files ending with .txt However, if the order of the filter parameters was changed to

`--include "*.txt" --exclude "*"`