### PR TITLE
Fixing skip PIP install airflow

### DIFF
--- a/airflow/hbc_deployment/scripts/deployment/ecs/build_push_image.sh
+++ b/airflow/hbc_deployment/scripts/deployment/ecs/build_push_image.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 eval $(aws --region us-east-1 ecr get-login --no-include-email)
-docker build -t 326027360148.dkr.ecr.us-east-1.amazonaws.com/airflow:latest .
+docker build --no-cache -t 326027360148.dkr.ecr.us-east-1.amazonaws.com/airflow:latest .
 docker push 326027360148.dkr.ecr.us-east-1.amazonaws.com/airflow:latest


### PR DESCRIPTION
adding --no-cache flag otherwise new changes can be missed on pip install